### PR TITLE
Fix template navigation scripts

### DIFF
--- a/1planpruebas.html
+++ b/1planpruebas.html
@@ -556,6 +556,8 @@
         }
       })();
     </script>
-    <script defer src=" js/back-home.js\></script>`r`n </body>
+    <script defer src="js/back-home.js"></script>
+    <script defer src="js/nav-inject.js"></script>
+  </body>
 </html>
 

--- a/2registrobugs.html
+++ b/2registrobugs.html
@@ -698,6 +698,8 @@
         }
       })();
     </script>
-    <script defer src=" js/back-home.js\></script>`r`n </body>
+    <script defer src="js/back-home.js"></script>
+    <script defer src="js/nav-inject.js"></script>
+  </body>
 </html>
 

--- a/3formatogap.html
+++ b/3formatogap.html
@@ -877,6 +877,8 @@ Crear plantilla y capacitar al equipo</textarea
         }
       })();
     </script>
-    <script defer src=" js/back-home.js\></script>`r`n </body>
+    <script defer src="js/back-home.js"></script>
+    <script defer src="js/nav-inject.js"></script>
+  </body>
 </html>
 

--- a/4roadmap.html
+++ b/4roadmap.html
@@ -1101,6 +1101,8 @@ Lista de asistencia y material de capacitación</textarea
         }
       })();
     </script>
-    <script defer src=" js/back-home.js\></script>`r`n </body>
+    <script defer src="js/back-home.js"></script>
+    <script defer src="js/nav-inject.js"></script>
+  </body>
 </html>
 

--- a/5finalintegrado.html
+++ b/5finalintegrado.html
@@ -1277,6 +1277,8 @@
         }
       })();
     </script>
-    <script defer src=" js/back-home.js\></script>`r`n </body>
+    <script defer src="js/back-home.js"></script>
+    <script defer src="js/nav-inject.js"></script>
+  </body>
 </html>
 

--- a/sesion1.html
+++ b/sesion1.html
@@ -1413,7 +1413,8 @@
       })();
     </script>
     <script defer src="js/back-home.js"></script>
-    <script defer src=" js/nav-inject.js\></script>`r`n </body>
-  </html>
+    <script defer src="js/nav-inject.js"></script>
+  </body>
+</html>
 
 


### PR DESCRIPTION
## Summary
- replace the corrupted back-home script tag at the end of the process templates with clean references to both shared scripts
- ensure the shared navigation loader is written without a stray BOM so the comment and script parse correctly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd85e68a3c83259498a0cccee0883f